### PR TITLE
Added optional key parameter to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ $adapter->publish('my_channel', 'HELLO WORLD');
 $adapter->publish('my_channel', ['hello' => 'world']);
 $adapter->publish('my_channel', 1);
 $adapter->publish('my_channel', false);
+$adapter->publish('my_channel', ['hello' => 'world'], 1);
 
 // publish multiple messages
 $messages = [

--- a/examples/KafkaPublishExample.php
+++ b/examples/KafkaPublishExample.php
@@ -31,3 +31,5 @@ $adapter = new \Superbalist\PubSub\Kafka\KafkaPubSubAdapter($producer, $consumer
 for ($x = 0; $x < 10; $x++) {
     $adapter->publish('my_channel', $x);
 }
+
+$adapter->publish('my_channel', 'With a key', 1);

--- a/src/KafkaPubSubAdapter.php
+++ b/src/KafkaPubSubAdapter.php
@@ -91,15 +91,14 @@ class KafkaPubSubAdapter implements PubSubAdapterInterface
     }
 
     /**
-     * Publish a message to a channel.
-     *
-     * @param string $channel
-     * @param mixed $message
+     * @param $channel
+     * @param $message
+     * @param null $key
      */
-    public function publish($channel, $message)
+    public function publish($channel, $message, $key = null)
     {
         $topic = $this->producer->newTopic($channel);
-        $topic->produce(RD_KAFKA_PARTITION_UA, 0, Utils::serializeMessage($message));
+        $topic->produce(RD_KAFKA_PARTITION_UA, 0, Utils::serializeMessage($message), $key);
     }
 
     /**

--- a/tests/KafkaPubSubAdapterTest.php
+++ b/tests/KafkaPubSubAdapterTest.php
@@ -256,6 +256,31 @@ class KafkaPubSubAdapterTest extends TestCase
         $adapter->publish('channel_name', ['hello' => 'world']);
     }
 
+    public function testPublishWithKey()
+    {
+        $topic = Mockery::mock(\RdKafka\Topic::class);
+        $topic->shouldReceive('produce')
+            ->withArgs([
+                RD_KAFKA_PARTITION_UA,
+                0,
+                '{"id:1", "hello":"world"}',
+                1
+            ])
+            ->once();
+
+        $producer = Mockery::mock(\RdKafka\Producer::class);
+        $producer->shouldReceive('newTopic')
+            ->with('channel_name')
+            ->once()
+            ->andReturn($topic);
+
+        $consumer = Mockery::mock(\RdKafka\KafkaConsumer::class);
+
+        $adapter = new KafkaPubSubAdapter($producer, $consumer);
+
+        $adapter->publish('channel_name', ['id' => 1, 'hello' => 'world'], 1);
+    }
+
     public function testPublishBatch()
     {
         $topic = Mockery::mock(\RdKafka\Topic::class);


### PR DESCRIPTION
Add an optional key parameter to the publish method. This is useful if you need related messages to go on the same partition and if you are using ksql.