### PR TITLE
Allow passing back of full rdkafka::message to subscriber handler

### DIFF
--- a/src/KafkaPubSubAdapter.php
+++ b/src/KafkaPubSubAdapter.php
@@ -75,7 +75,7 @@ class KafkaPubSubAdapter implements PubSubAdapterInterface
                     if ($payload === 'unsubscribe') {
                         $isSubscriptionLoopActive = false;
                     } else {
-                        call_user_func($handler, $payload);
+                        call_user_func_array($handler, [$payload, $message]);
                     }
 
                     $this->consumer->commitAsync($message);


### PR DESCRIPTION
This is useful to allow viewing of the message metadata.